### PR TITLE
Use a static exchange name

### DIFF
--- a/asgi_amqp/core.py
+++ b/asgi_amqp/core.py
@@ -31,7 +31,7 @@ class AMQPChannelLayer(BaseChannelLayer):
         kombu.serialization.enable_insecure_serializers()
 
         self.url = url or 'amqp://guest:guest@localhost:5672/%2F'
-        self.prefix = prefix + 'tower:{}'.format(socket.gethostname())
+        self.prefix = prefix + 'tower:websocket'
         self.exchange = kombu.Exchange(self.prefix, type='topic')
 
         self.tdata = threading.local()


### PR DESCRIPTION
This helps when multiple nodes need to consume the same data.